### PR TITLE
Add missing dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "mmap-io": "^0.9.4"
   },
   "devDependencies": {
-    "tape-catch": "^1.0.4"
+    "tape-catch": "^1.0.4",
+    "tap-difflet": "^0.4.0",
+    "tape": "^4.2.2"
   },
   "scripts": {
     "compile": "babel --blacklist=regenerator -d src/ es6/",


### PR DESCRIPTION
Needed to run the tests

(tape is a peerDependencies of tape-catch which are no longer installed automatically since npm 3)